### PR TITLE
Updated log4j.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.13.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.13.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Old log4j had security vulnerabilities (although it's only used for testing so not a big deal).