### PR TITLE
Updated to latest mysql 5.1.49 connector.

### DIFF
--- a/tf-api-impl/pom.xml
+++ b/tf-api-impl/pom.xml
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.39</version>
+			<version>5.1.49</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- / For testing database caching in *.dao.* packages. -->


### PR DESCRIPTION
Updated to latest mysql 5.1.* library.  Considering migration to 8.* connectors but API changes would necessitate other changes and the 5.1.* libraries are still actively developed.